### PR TITLE
Finalize CI changes for #1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           curl -L https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/$DIRECTSTORAGE_VERSION -o microsoft.direct3d.directstorage.$DIRECTSTORAGE_VERSION.nupkg
           unzip microsoft.direct3d.directstorage.$DIRECTSTORAGE_VERSION.nupkg native/winmd/Microsoft.Direct3D.DirectStorage.winmd
+          mkdir -p .windows/winmd/
           mv native/winmd/Microsoft.Direct3D.DirectStorage.winmd .windows/winmd/
           rm native -rf
           rm microsoft.direct3d.directstorage.$DIRECTSTORAGE_VERSION.nupkg


### PR DESCRIPTION
PR #1 wasn't yet ready for merging after removing the unnecessarily checked-in `.winmd` file (only needed to regenerate the file), but this broke the CI step that validates that the generated code remains unchanged when generated freshly against upstream metadata.

---

In addition I had intended to make the `loaded` feature automatically replace the `#[link = "dstorage"]` functions from generated code, but their existence in the codebase always forces a linking action to `dstorage.lib` regardless of being referenced.  We rely on a similar feature (`#[link = "xxx"]` attribute on an empty `extern "C" {}` import block) in the `ndk` crate though, and would need to find a different way in the generator.
