### PR TITLE
Generate custom `winmd` from headers with improved annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,21 +39,40 @@ jobs:
       - name: Cargo clippy with minimal-versions
         run: cargo +stable clippy --workspace --all-targets -- -D warnings
 
-  generate-rust:
-    name: Generate Rust crate
-    runs-on: ubuntu-latest
+  generate-winmd:
+    name: Generate winmd
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Clean
-        run: rm -rf .windows/winmd/* src/Microsoft.rs
-      - name: Download winmd
+        run: Remove-Item -Recurse -Force -ErrorAction SilentlyContinue .windows/winmd/
+      - name: Configure environment
+        shell: pwsh
         run: |
-          curl -L https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/$DIRECTSTORAGE_VERSION -o microsoft.direct3d.directstorage.$DIRECTSTORAGE_VERSION.nupkg
-          unzip microsoft.direct3d.directstorage.$DIRECTSTORAGE_VERSION.nupkg native/winmd/Microsoft.Direct3D.DirectStorage.winmd
-          mkdir -p .windows/winmd/
-          mv native/winmd/Microsoft.Direct3D.DirectStorage.winmd .windows/winmd/
-          rm native -rf
-          rm microsoft.direct3d.directstorage.$DIRECTSTORAGE_VERSION.nupkg
+          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64" >> $env:GITHUB_PATH
+          ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
+      - name: Generate
+        run: dotnet build .metadata
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: metadata
+          path: .windows/winmd
+
+  generate-rust:
+    name: Generate Rust crate
+    runs-on: ubuntu-latest
+    needs: generate-winmd
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clean
+        run: rm -rf .windows/winmd/ src/Microsoft_Direct3D_DirectStorage.rs
+      - name: Download winmd
+        uses: actions/download-artifact@v4
+        with:
+          name: metadata
+          path: .windows/winmd
       - name: Generate
         run: cargo r -p api_gen
       - name: Upload crate source
@@ -62,4 +81,4 @@ jobs:
           name: crate-source
           path: src/
       - name: Diff generated Rust code
-        run: test -z "$(git status --porcelain)" || (echo "::error::Generated files are different, please regenerate with cargo run -p api_gen!"; git status; false)
+        run: test -z "$(git status --porcelain -- ':!.windows')" || (echo "::error::Generated files are different, please regenerate with cargo run -p api_gen!"; git status; false)

--- a/.metadata/Microsoft.Direct3D.DirectStorage.Manual.cs
+++ b/.metadata/Microsoft.Direct3D.DirectStorage.Manual.cs
@@ -1,0 +1,105 @@
+// Missing constants from https://learn.microsoft.com/en-us/windows/win32/dstorage/dstorage-constants
+
+using Windows.Win32.Foundation;
+using Windows.Win32.Foundation.Metadata;
+
+namespace Microsoft.Direct3D.DirectStorage
+{
+    public static partial class Apis
+    {
+        public const uint FACILITY_GAME = 2340u;
+
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_ACCESS_VIOLATION = -1994129399;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_ALREADY_RUNNING = -1994129407;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_BCPACK_BAD_DATA = -1994129355;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_BCPACK_BAD_HEADER = -1994129356;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_COMPRESSED_DATA_TOO_LARGE = -1994129351;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_DECOMPRESSION_ERROR = -1994129360;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_DECRYPTION_ERROR = -1994129354;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_DEPRECATED_PREVIEW_GDK = -1994129384;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_END_OF_FILE = -1994129401;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_FILE_NOT_OPEN = -1994129397;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_FILE_TOO_FRAGMENTED = -1994129352;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_FILEBUFFERING_REQUIRES_DISABLED_BYPASSIO = -1994129343;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INDEX_BOUND = -1994129387;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_BCPACK_MODE = -1994129395;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_CLUSTER_SIZE = -1994129391;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_DESTINATION_SIZE = -1994129393;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_DESTINATION_TYPE = -1994129344;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_FENCE = -1994129374;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_FILE_HANDLE = -1994129385;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_FILE_OFFSET = -1994129382;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_INTERMEDIATE_SIZE = -1994129380;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_MEMORY_QUEUE_PRIORITY = -1994129372;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_QUEUE_CAPACITY = -1994129405;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_QUEUE_PRIORITY = -1994129389;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_SOURCE_TYPE = -1994129381;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_STAGING_BUFFER_SIZE = -1994129376;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_STATUS_ARRAY = -1994129373;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_INVALID_SWIZZLE_MODE = -1994129394;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_IO_TIMEOUT = -1994129386;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_NOT_RUNNING = -1994129406;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_PASSTHROUGH_ERROR = -1994129353;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_QUEUE_CLOSED = -1994129392;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_REQUEST_TOO_LARGE = -1994129400;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_RESERVED_FIELDS = -1994129396;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_STAGING_BUFFER_LOCKED = -1994129377;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_STAGING_BUFFER_TOO_SMALL = -1994129375;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_SYSTEM_NOT_SUPPORTED = -1994129379;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_TOO_MANY_FILES = -1994129388;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_TOO_MANY_QUEUES = -1994129390;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_UNSUPPORTED_FILE = -1994129398;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_UNSUPPORTED_VOLUME = -1994129403;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_XVD_DEVICE_NOT_SUPPORTED = -1994129404;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_XVD_NOT_REGISTERED = -1994129383;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_ZLIB_BAD_DATA = -1994129358;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_ZLIB_BAD_HEADER = -1994129359;
+        [NativeTypeName("HRESULT")]
+        public const int E_DSTORAGE_ZLIB_PARITY_FAIL = -1994129357;
+    }
+}

--- a/.metadata/dstorage.cpp
+++ b/.metadata/dstorage.cpp
@@ -1,0 +1,1 @@
+#include <dstorage.h>

--- a/.metadata/emitter.settings.rsp
+++ b/.metadata/emitter.settings.rsp
@@ -1,0 +1,4 @@
+--memberRemap
+IDStorageFactory::SetDebugFlags::flags=[AssociatedEnum("DSTORAGE_DEBUG")]
+IDStorageQueue::RetrieveErrorRecord::record=[RetVal]
+IDStorageQueue::Query::info=[RetVal]

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.56.13-preview">
+    <PropertyGroup Label="Globals">
+        <OutputWinmd>../.windows/winmd/Microsoft.Direct3D.DirectStorage.winmd</OutputWinmd>
+        <WinmdVersion>1.2.2</WinmdVersion>
+        <AdditionalIncludes>$(PkgMicrosoft_Direct3D_DirectStorage)\native\include</AdditionalIncludes>
+        <ExcludeFromCrossarch>Microsoft.Direct3D.DirectStorage</ExcludeFromCrossarch>
+    </PropertyGroup>
+
+    <Target Name="CopyNativeLibs" AfterTargets="Build">
+        <ItemGroup>
+            <DirectStorageNativeFiles Include="$(PkgMicrosoft_Direct3D_DirectStorage)\native\*\x64\*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(DirectStorageNativeFiles)" DestinationFolder="../.windows/x64" />
+    </Target>
+
+    <ItemGroup>
+        <EmitterRsp Include="emitter.settings.rsp"/>
+        <ImportLibs Include="$(PkgMicrosoft_Direct3D_DirectStorage)\native\lib\x64\dstorage.lib" />
+
+        <Partition Include="dstorage.cpp">
+            <TraverseFiles>
+                $(PkgMicrosoft_Direct3D_DirectStorage)\native\include\dstorage.h;
+                $(PkgMicrosoft_Direct3D_DirectStorage)\native\include\dstorageerr.h
+            </TraverseFiles>
+            <Namespace>Microsoft.Direct3D.DirectStorage</Namespace>
+        </Partition>
+
+        <PackageReference Include="Microsoft.Direct3D.DirectStorage" Version="1.2.2" GeneratePathProperty="true">
+            <IncludeAssets>none</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to `direct-storage-rs`
+
+## Regenerate `DirectStorage` metadata and bindings
+
+When the `windows` (and `windows-core` and `windows-bindgen`) crates or `DirectStorage` NuGet packages are updated, or when changes are made to the bindings configuration, some steps need to be ran to update Rust code files.  This process is automated as a CI job, but described below after making various changes:
+
+1. Update `windows` dependency versions in [`Cargo.toml`](Cargo.toml) and `Microsoft.Direct3D.DirectStorage` version in [`generate.proj`](.metadata/generate.proj) (if applicable);
+2. Make changes to the metadata configuration in the [`.metadata/`](.metadata/) folder (if applicable);
+3. (Re)generate [`.winmd`](.windows/winmd/Microsoft.Direct3D.DirectStorage.winmd) metadata by running:
+   ```sh
+   dotnet build .metadata
+   ```
+4. Make changes to the Rust bindings generation configuration in [`api_gen/`](api_gen/) and [`bindings.txt`](bindings.txt) (if applicable);
+5. (Re)generate Rust code ([`src/Microsoft_Direct3D_DirectStorage.rs`](src/Microsoft_Direct3D_DirectStorage.rs)) by running:
+   ```sh
+   cargo r -p api_gen
+   ```

--- a/bindings.txt
+++ b/bindings.txt
@@ -1,5 +1,5 @@
 --in .windows/winmd/
---out src/Microsoft.rs
+--out src/Microsoft_Direct3D_DirectStorage.rs
 
 --filter
     Microsoft.Direct3D.DirectStorage

--- a/examples/benchmark/main.rs
+++ b/examples/benchmark/main.rs
@@ -178,7 +178,7 @@ pub fn main() {
             let factory: IDStorageFactory =
                 DStorageGetFactory().expect("Can't get DirectStorage factory");
 
-            factory.SetDebugFlags(DSTORAGE_DEBUG_SHOW_ERRORS.0 | DSTORAGE_DEBUG_BREAK_ON_ERROR.0);
+            factory.SetDebugFlags(DSTORAGE_DEBUG_SHOW_ERRORS | DSTORAGE_DEBUG_BREAK_ON_ERROR);
 
             factory
         };
@@ -574,8 +574,7 @@ fn run_test(
             sleep(Duration::from_secs(5));
         }
 
-        let mut error_record = Default::default();
-        unsafe { queue.RetrieveErrorRecord(&mut error_record) };
+        let error_record = unsafe { queue.RetrieveErrorRecord() };
 
         if error_record.FirstFailure.HResult.is_err() {
             println!(

--- a/examples/hello_direct_storage/main.rs
+++ b/examples/hello_direct_storage/main.rs
@@ -200,8 +200,7 @@ fn main() {
         }
     };
 
-    let mut error_record = Default::default();
-    unsafe { queue.RetrieveErrorRecord(&mut error_record) };
+    let error_record = unsafe { queue.RetrieveErrorRecord() };
 
     if error_record.FailureCount > 0 {
         println!(

--- a/src/Microsoft_Direct3D_DirectStorage.rs
+++ b/src/Microsoft_Direct3D_DirectStorage.rs
@@ -63,6 +63,18 @@ pub mod Direct3D {
             }
             DStorageSetConfiguration(configuration).ok()
         }
+        #[inline]
+        pub unsafe fn DStorageSetConfiguration1(
+            configuration: *const DSTORAGE_CONFIGURATION1,
+        ) -> ::windows_core::Result<()> {
+            #[link(name = "dstorage")]
+            extern "system" {
+                pub fn DStorageSetConfiguration1(
+                    configuration: *const DSTORAGE_CONFIGURATION1,
+                ) -> ::windows_core::HRESULT;
+            }
+            DStorageSetConfiguration1(configuration).ok()
+        }
         #[repr(transparent)]
         #[derive(
             ::core::cmp::PartialEq, ::core::cmp::Eq, ::core::fmt::Debug, ::core::clone::Clone,
@@ -351,10 +363,10 @@ pub mod Direct3D {
                 )
                 .from_abi(result__)
             }
-            pub unsafe fn SetDebugFlags(&self, flags: u32) {
+            pub unsafe fn SetDebugFlags(&self, flags: DSTORAGE_DEBUG) {
                 (::windows_core::Interface::vtable(self).SetDebugFlags)(
                     ::windows_core::Interface::as_raw(self),
-                    flags,
+                    flags.0 as _,
                 )
             }
             pub unsafe fn SetStagingBufferSize(&self, size: u32) -> ::windows_core::Result<()> {
@@ -500,17 +512,21 @@ pub mod Direct3D {
                     ::windows_core::Interface::as_raw(self),
                 )
             }
-            pub unsafe fn RetrieveErrorRecord(&self, record: *mut DSTORAGE_ERROR_RECORD) {
+            pub unsafe fn RetrieveErrorRecord(&self) -> DSTORAGE_ERROR_RECORD {
+                let mut result__ = ::std::mem::zeroed();
                 (::windows_core::Interface::vtable(self).RetrieveErrorRecord)(
                     ::windows_core::Interface::as_raw(self),
-                    record,
-                )
+                    &mut result__,
+                );
+                ::std::mem::transmute(result__)
             }
-            pub unsafe fn Query(&self, info: *mut DSTORAGE_QUEUE_INFO) {
+            pub unsafe fn Query(&self) -> DSTORAGE_QUEUE_INFO {
+                let mut result__ = ::std::mem::zeroed();
                 (::windows_core::Interface::vtable(self).Query)(
                     ::windows_core::Interface::as_raw(self),
-                    info,
-                )
+                    &mut result__,
+                );
+                ::std::mem::transmute(result__)
             }
         }
         ::windows_core::imp::interface_hierarchy!(IDStorageQueue, ::windows_core::IUnknown);
@@ -611,18 +627,22 @@ pub mod Direct3D {
                     ::windows_core::Interface::as_raw(self),
                 )
             }
-            pub unsafe fn RetrieveErrorRecord(&self, record: *mut DSTORAGE_ERROR_RECORD) {
+            pub unsafe fn RetrieveErrorRecord(&self) -> DSTORAGE_ERROR_RECORD {
+                let mut result__ = ::std::mem::zeroed();
                 (::windows_core::Interface::vtable(self)
                     .base__
                     .RetrieveErrorRecord)(
-                    ::windows_core::Interface::as_raw(self), record
-                )
+                    ::windows_core::Interface::as_raw(self), &mut result__
+                );
+                ::std::mem::transmute(result__)
             }
-            pub unsafe fn Query(&self, info: *mut DSTORAGE_QUEUE_INFO) {
+            pub unsafe fn Query(&self) -> DSTORAGE_QUEUE_INFO {
+                let mut result__ = ::std::mem::zeroed();
                 (::windows_core::Interface::vtable(self).base__.Query)(
                     ::windows_core::Interface::as_raw(self),
-                    info,
-                )
+                    &mut result__,
+                );
+                ::std::mem::transmute(result__)
             }
             pub unsafe fn EnqueueSetEvent<P0>(&self, handle: P0)
             where
@@ -719,19 +739,23 @@ pub mod Direct3D {
                     .base__
                     .GetErrorEvent)(::windows_core::Interface::as_raw(self))
             }
-            pub unsafe fn RetrieveErrorRecord(&self, record: *mut DSTORAGE_ERROR_RECORD) {
+            pub unsafe fn RetrieveErrorRecord(&self) -> DSTORAGE_ERROR_RECORD {
+                let mut result__ = ::std::mem::zeroed();
                 (::windows_core::Interface::vtable(self)
                     .base__
                     .base__
                     .RetrieveErrorRecord)(
-                    ::windows_core::Interface::as_raw(self), record
-                )
+                    ::windows_core::Interface::as_raw(self), &mut result__
+                );
+                ::std::mem::transmute(result__)
             }
-            pub unsafe fn Query(&self, info: *mut DSTORAGE_QUEUE_INFO) {
+            pub unsafe fn Query(&self) -> DSTORAGE_QUEUE_INFO {
+                let mut result__ = ::std::mem::zeroed();
                 (::windows_core::Interface::vtable(self).base__.base__.Query)(
                     ::windows_core::Interface::as_raw(self),
-                    info,
-                )
+                    &mut result__,
+                );
+                ::std::mem::transmute(result__)
             }
             pub unsafe fn EnqueueSetEvent<P0>(&self, handle: P0)
             where
@@ -848,10 +872,10 @@ pub mod Direct3D {
             DSTORAGE_CUSTOM_DECOMPRESSION_FLAGS = DSTORAGE_CUSTOM_DECOMPRESSION_FLAGS(1u32);
         pub const DSTORAGE_CUSTOM_DECOMPRESSION_FLAG_NONE: DSTORAGE_CUSTOM_DECOMPRESSION_FLAGS =
             DSTORAGE_CUSTOM_DECOMPRESSION_FLAGS(0u32);
-        pub const DSTORAGE_DEBUG_BREAK_ON_ERROR: DSTORAGE_DEBUG = DSTORAGE_DEBUG(2u32);
-        pub const DSTORAGE_DEBUG_NONE: DSTORAGE_DEBUG = DSTORAGE_DEBUG(0u32);
-        pub const DSTORAGE_DEBUG_RECORD_OBJECT_NAMES: DSTORAGE_DEBUG = DSTORAGE_DEBUG(4u32);
-        pub const DSTORAGE_DEBUG_SHOW_ERRORS: DSTORAGE_DEBUG = DSTORAGE_DEBUG(1u32);
+        pub const DSTORAGE_DEBUG_BREAK_ON_ERROR: DSTORAGE_DEBUG = DSTORAGE_DEBUG(2i32);
+        pub const DSTORAGE_DEBUG_NONE: DSTORAGE_DEBUG = DSTORAGE_DEBUG(0i32);
+        pub const DSTORAGE_DEBUG_RECORD_OBJECT_NAMES: DSTORAGE_DEBUG = DSTORAGE_DEBUG(4i32);
+        pub const DSTORAGE_DEBUG_SHOW_ERRORS: DSTORAGE_DEBUG = DSTORAGE_DEBUG(1i32);
         pub const DSTORAGE_DISABLE_BUILTIN_CPU_DECOMPRESSION: i32 = -1i32;
         pub const DSTORAGE_GET_REQUEST_FLAG_SELECT_ALL: DSTORAGE_GET_REQUEST_FLAGS =
             DSTORAGE_GET_REQUEST_FLAGS(3u32);
@@ -1169,7 +1193,7 @@ pub mod Direct3D {
         }
         #[repr(transparent)]
         #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]
-        pub struct DSTORAGE_DEBUG(pub u32);
+        pub struct DSTORAGE_DEBUG(pub i32);
         impl ::core::marker::Copy for DSTORAGE_DEBUG {}
         impl ::core::clone::Clone for DSTORAGE_DEBUG {
             fn clone(&self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@ use std::mem::{transmute_copy, ManuallyDrop};
 
 use windows_core::Interface;
 
-mod Microsoft;
+mod Microsoft_Direct3D_DirectStorage;
 #[cfg(feature = "loaded")]
 pub mod runtime_loaded;
-pub use Microsoft::Direct3D::DirectStorage::*;
+pub use Microsoft_Direct3D_DirectStorage::Direct3D::DirectStorage::*;
 
 /// Create a temporary "owned" copy inside a [`ManuallyDrop`] without increasing the refcount or
 /// moving away the source variable.


### PR DESCRIPTION
The winmd shipped with the NuGet package has an [indecisive license][1], as it's intended to fall under the MIT license just like other code files, but is strictly a binary blob.  At the same time the metadata [isn't representing the headers as conveniently and completely][2] as we'd like in our Rust bindings, but unfortunately there is no upstream source available to reference or contribute to, where we can tweak and improve how the NuGet `winmd` is generated.

The metadata description introduced here tries to reproduce the original metadata as closely as possible, while following the improvements [that I requested upstream][2] and [maintaining the `int` type for `DSTORAGE_DEBUG`][3].
(windows-rs will generate automatic type conversions for this, as annotating the parameter to be an integer type in the low-level bindings isn't correct)

[1]: https://github.com/microsoft/DirectStorage/issues/8#issuecomment-1875760330
[2]: https://github.com/microsoft/DirectStorage/issues/38
[3]: https://github.com/microsoft/win32metadata/issues/1822#issuecomment-1894407892
