### PR TITLE
Allow using `windows-targets` `0.52` next to `0.53`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libloading = { version = "0.8", optional = true }
 once_cell = { version = "1.19", optional = true }
 windows = { version = ">=0.57, <=0.59", features = ["Win32_Foundation", "Win32_Graphics_Direct3D12", "Win32_Storage_FileSystem"], default-features = false }
 windows-core = ">=0.57, <=0.59"
-windows-targets = "0.53"
+windows-targets = ">=0.52, <=0.53"
 
 [dev-dependencies]
 windows = { version = ">=0.57, <=0.59", features = ["Win32_Foundation", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Graphics_Dxgi_Common", "Win32_System_WindowsProgramming", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Threading"], default-features = false }


### PR DESCRIPTION
In #26 we bumped `windows-bindgen` to `0.59` which now generates `#[link] extern "system" { fn ... }` blocks via the `link!()` macro in the `windows_targets` crate.  I quickly added a dependency on `0.53` there, but the macro is also available in `0.52` which is also still used by `windows 0.57-0.58`.  By not allowing `direct-storage` to use `windows-bindgen 0.52`, the user always has to accept a crate duplicate until they are ready to upgrade to `windows 0.59`.  Turn this into a `>=0.52, <=0.53` version range to support either revision of the crate.
